### PR TITLE
V6.4, complete compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,8 @@
 - 각 파일은 markdown 파일로 구성됩니다.
 - [elastic_search_docs_link](https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html)
 
+
+#### Environment
+- docker 6.4.1(latest)
+- Elasticsearch, Kibana, Logstash
+

--- a/v6.4/docker-setting.md
+++ b/v6.4/docker-setting.md
@@ -39,6 +39,18 @@
         - docker-compose up을 하기 위한 설정 파일을 생성한다.
         - 설정파일을 수정후 구동시켜 본다
         - 추가 Optimization 과정은 이후 진행토록 한다.
+    - xpack 설정 끄기(refer : [elatov](https://elatov.github.io/2017/09/run-elasticsearch-and-kibana-on-docker/))
+        - 기본적으로 elasticsearch container에는 xpack이 구동된다.
+        - docker-compose.yml의 환경변수를 수정한다.
+            ```
+            "XPACK_SECURITY_ENABLED=false"
+            "XPACK_GRAPH_ENABLE=false"
+            "XPACK_WATCHER_ENABLED=false"
+            "XPACK_ML_ENABLED=false"
+            "XPACK_MONITORING_ENABLED=false"
+            "XPACK_MONITORING_UI_CONTAINER_ELASTICSEARCH_ENABLED"
+            ```
+        - docker-compose up을 하게 되면 설정이 초기화 되는 현상 발생, 다른 방법 강구
 - kibana w/ docker
     - reference : [Kibana w/ Docker](https://www.elastic.co/guide/en/kibana/current/docker.html)
     - docker-compose.yml
@@ -46,5 +58,32 @@
         - [detail option kibana](https://www.elastic.co/guide/en/kibana/current/settings.html)
         - volumes 설정이 먹지 않는다.
             - Not a Directory와 같은 에러 출력
+            - 로컬에 파일(kibana.yml)이 있어야 구성 가능하다.
+- logstash w/ docker
+    - reference : [Logstash w/ Docker](https://www.elastic.co/guide/en/logstash/current/docker.html)
+
+- docker
+    - docker __exec__ vs docker **attach**
+        - exec의 경우 쉘 지정이 가능하며, 중단시에 컨테이너가 죽지 않는다.
+        - attach의 경우 bash로 구동되며, 중단시에 컨테이너가 같이 stop된다.
+            - reference : [code.i](https://code.i-harness.com/ko-kr/q/1d86c2e)
+    - docker volume container
+        - reference : [joinc](https://www.joinc.co.kr/w/man/12/docker/Guide/DataWithContainer)
+        ```
+        docker volume ls # 볼륨 컨테이너 목록 확인
+        docker volume prune # 비사용 볼륨 컨테이너 제거
+        docker volume inspect <container name> # 볼륨 상세 정보 확인
+        ```
+        - **prune을 함부로 사용해선 안된다. 기존 컨테이너가 망가지는 경우가 발생한다.**
+        - **컨테이너가 망가질 경우, 제거 후, compose up을 해주어야 한다.**
+        - **다른 컨테이너와 결부되어 있는가를 확인 후 제거해야한다.**
+    - docker network
+        - reference : [official docker](https://docs.docker.com/compose/networking/)
+        ```
+        docker network ls # 네트워크 어댑터 확인
+        docker network prune # 비사용 어댑터 제거
+        docker network inspect <network name> # 네트워크 상세 정보 확인
+
+        
 
 

--- a/v6.4/docker-setting.md
+++ b/v6.4/docker-setting.md
@@ -1,5 +1,6 @@
 ### docker-setting
 ---
+- reference : [ES with Docker](https://www.elastic.co/guide/en/elasticsearch/reference/6.3/docker.html)
 - docker image download
     ```
     docker pull docker.elastic.co/elasticsearch/elasticsearch:latest
@@ -25,7 +26,25 @@
             $ screen ~/Library/Containers/com.docker.docker/Data/com.docker.driver.amd64-linux/tty
             # 이대로 실행시키면 cannot exec 메세지 발생
 
+            ~/Library/Containers/com.docker.docker/Data/vms/0
+            # 이 경로에 tty가 존재한다.
+            
+            cd ~/Library/Containers/com.docker.docker/Data/vms/0
+            screen tty
             sudo sysctl -w vm.max_map_count=262144
+            cat /proc/sys/vm/max_map_count # 262144인지 확인
             ```
+            이후 screen에서 탈출하기 위해 'ctrl+A+\\'를 입력한다.
+    - docker-compose.yml 파일 작성
+        - docker-compose up을 하기 위한 설정 파일을 생성한다.
+        - 설정파일을 수정후 구동시켜 본다
+        - 추가 Optimization 과정은 이후 진행토록 한다.
+- kibana w/ docker
+    - reference : [Kibana w/ Docker](https://www.elastic.co/guide/en/kibana/current/docker.html)
+    - docker-compose.yml
+        - elasticsearch보다 간단하며, 기본 설정만 돌려도 된다
+        - [detail option kibana](https://www.elastic.co/guide/en/kibana/current/settings.html)
+        - volumes 설정이 먹지 않는다.
+            - Not a Directory와 같은 에러 출력
 
 

--- a/v6.4/docker-setting.md
+++ b/v6.4/docker-setting.md
@@ -1,0 +1,31 @@
+### docker-setting
+---
+- docker image download
+    ```
+    docker pull docker.elastic.co/elasticsearch/elasticsearch:latest
+    ```
+- running command
+    - development mode
+        ```
+        docker run -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:latest
+        ```
+    - production mode
+        - Linux
+            - VM 설정을 해주어야 한다(vm.max_map_count)
+            - 확인 방법
+                ```
+                $ grep vm.max_map_count /etc/sysctl.conf
+
+                $ sysctl -w vm.max_map_count=262144
+                ```
+        - Mac
+            - xhyve virtual machine
+            - docker
+            ```
+            $ screen ~/Library/Containers/com.docker.docker/Data/com.docker.driver.amd64-linux/tty
+            # 이대로 실행시키면 cannot exec 메세지 발생
+
+            sudo sysctl -w vm.max_map_count=262144
+            ```
+
+

--- a/v6.4/elasticsearch/docker-compose.yml
+++ b/v6.4/elasticsearch/docker-compose.yml
@@ -1,13 +1,20 @@
-version: '2.2'
+version: '3.1' # version 2, kibana가 localhost에수 구동되지 않음
 services:
   elasticsearch:
     #image: docker.elastic.co/elasticsearch/elasticsearch:6.3.2
     image: docker.elastic.co/elasticsearch/elasticsearch:6.4.1
     container_name: elasticsearch
+    hostname: elasticsearch # netowrks, esnet에서 elasticsearch라는 이름으로 호출 가능
     environment:
       - cluster.name=docker-cluster
       - bootstrap.memory_lock=true
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - "XPACK_SECURITY_ENABLED=false"
+      - "XPACK_GRAPH_ENABLE=false"
+      - "XPACK_WATCHER_ENABLED=false"
+      - "XPACK_ML_ENABLED=false"
+      - "XPACK_MONITORING_ENABLED=false"
+      - "XPACK_MONITORING_UI_CONTAINER_ELASTICSEARCH_ENABLED"
     ulimits:
       memlock:
         soft: -1 #ulimits soft=-1
@@ -22,12 +29,20 @@ services:
     #image: docker.elastic.co/elasticsearch/elasticsearch:6.3.2
     image: docker.elastic.co/elasticsearch/elasticsearch:6.4.1
     container_name: elasticsearch2
+    hostname: elasticsearch2
     environment:
       - cluster.name=docker-cluster
       - bootstrap.memory_lock=true
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m" #xms : Heap Min Size, xmx : Heap Max size
       - "discovery.zen.ping.unicast.hosts=elasticsearch"
        # 유니캐스트 검색, https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-discovery-zen.html
+      - "XPACK_SECURITY_ENABLED=false"
+      - "XPACK_GRAPH_ENABLE=false"
+      - "XPACK_WATCHER_ENABLED=false"
+      - "XPACK_ML_ENABLED=false"
+      - "XPACK_MONITORING_ENABLED=false"
+      - "XPACK_MONITORING_UI_CONTAINER_ELASTICSEARCH_ENABLED"
+      # xpack deprecated
     ulimits:
       memlock:
         soft: -1
@@ -36,6 +51,28 @@ services:
       - esdata2:/usr/share/elasticsearch/data
     networks:
       - esnet
+      # https://docs.docker.com/compose/networking/#specify-custom-networks
+  kibana:
+    image: docker.elastic.co/kibana/kibana:6.4.1 # kibana 이미지 사용
+    container_name: kibana
+    hostname: kibana
+    #network_mode: esnet
+    #network_mode: host # localhost 참조 가능
+    ports:
+      - "5601:5601"
+    networks:
+      - esnet
+    environment:
+      - "ELASTICSEARCH_URL=http://elasticsearch:9200"
+      # https://discuss.elastic.co/t/kibana-docker-image-doesnt-connect-to-elasticsearch-image/79511/4
+      # 키바나 컨테이너 안에서의 localhost는 kibana 자기 자신을 가르키게 됨.
+      # --net=host로 로컬을 당겨쓸수 있음(어댑터 변경)
+  #logstash:
+  #  hostname: logstash
+  #  container_name: logstash
+  #  network: esnet
+
+
 
 volumes:
   esdata1:

--- a/v6.4/elasticsearch/docker-compose.yml
+++ b/v6.4/elasticsearch/docker-compose.yml
@@ -1,0 +1,50 @@
+version: '2.2'
+services:
+  elasticsearch:
+    #image: docker.elastic.co/elasticsearch/elasticsearch:6.3.2
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.4.1
+    container_name: elasticsearch
+    environment:
+      - cluster.name=docker-cluster
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    ulimits:
+      memlock:
+        soft: -1 #ulimits soft=-1
+        hard: -1
+    volumes:
+      - esdata1:/usr/share/elasticsearch/data
+    ports:
+      - 9200:9200
+    networks:
+      - esnet
+  elasticsearch2:
+    #image: docker.elastic.co/elasticsearch/elasticsearch:6.3.2
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.4.1
+    container_name: elasticsearch2
+    environment:
+      - cluster.name=docker-cluster
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m" #xms : Heap Min Size, xmx : Heap Max size
+      - "discovery.zen.ping.unicast.hosts=elasticsearch"
+       # 유니캐스트 검색, https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-discovery-zen.html
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    volumes:
+      - esdata2:/usr/share/elasticsearch/data
+    networks:
+      - esnet
+
+volumes:
+  esdata1:
+    driver: local
+  esdata2:
+    driver: local
+  # https://docs.docker.com/engine/reference/commandline/volume_create/#related-commands
+  # driver의 의미 : http://tech.cloudz-labs.io/posts/docker/volume/
+  # nfs, aws s3 등 다양한 드라이버 모듈이 존재할 수 있음
+
+networks:
+  esnet:

--- a/v6.4/elasticsearch_v6.4.md
+++ b/v6.4/elasticsearch_v6.4.md
@@ -50,6 +50,8 @@
         {
             "name": "Sion Kim"
         }
+
+        
         GET /customer/_doc/1?pretty
         ```
         - index : customer, id = 1

--- a/v6.4/elasticsearch_v6.4.md
+++ b/v6.4/elasticsearch_v6.4.md
@@ -1,0 +1,70 @@
+### Elasticsearch 6.4
+---
+- type이 제거됨
+    - 내부적 index로만 관리된다
+- shard
+    - 하나의 인덱스에 대하여 여러 노드에 분할하여 저장 가능
+    - 클러스터의 모든 노드에서 호스팅 가능
+- replica
+    - 복제본
+    - 하나의 인덱스에 대해 여러개로 복제하여 저장
+    - 정확히 인덱스에 해당하는 샤드별 복제
+- 버전 지원 관련
+    - java 8, jdk 1.8.0_131이상
+- 실행 방법
+    ```
+    ./elasticsearch -Ecluster.name=my_cluster_name -Enode.name=my_node_name
+    ```
+- Exploring Your Cluster
+    - REST API
+        - 클러스터 및 노드의 상태 확인 가능
+        - CRUD 및 인덱스에 관한 작업
+        - 페이징, 정렬, 필터링 등 가능
+    - Cluster Health
+        - GET /_cat/health?v
+            - _cat api
+                - 클러스터 헬스 체크를 하기 위한 명령어
+                    ```
+                    curl -X GET "localhost:9200/_cat/health?v"
+                    ```
+        - 상태
+            - Green
+            - Yellow
+                - 모든 데이터가 사용 가능하나, 일부 replica에서 할당되지 않음
+            - Red
+                - 특정 이유에 따라 몇 데이터가 활용 가능하지 않음
+    - Index
+        - List All Indices
+            ```
+            GET /_cat/indices?v
+            ```
+        - Create an Index
+            ```
+            PUT /customer?pretty
+            GET /_cat/indices?v
+            ```
+            - pretty : 정리된 자료를 보기 위함
+    - Index and Query a Document
+        ```
+        PUT /customer/_doc/1?pretty
+        {
+            "name": "Sion Kim"
+        }
+        GET /customer/_doc/1?pretty
+        ```
+        - index : customer, id = 1
+        - 결과 내용에서 _doc이라는 type이 존재
+    - Delete an Index
+        ```
+        DELETE /customer?pretty
+        GET /_cat/indices?v
+        ```
+        
+
+
+
+
+
+    
+    
+    

--- a/v6.4/kibana/docker-compose.yml
+++ b/v6.4/kibana/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '2'
+services:
+  kibana:
+    image: docker.elastic.co/kibana/kibana:6.4.1 # kibana 이미지 사용
+    #volumes:
+    #  - ./kibana.yml:/usr/share/kibana/config/kibana.yml # 설정파일 매핑

--- a/v6.4/kibana/docker-compose.yml
+++ b/v6.4/kibana/docker-compose.yml
@@ -1,6 +1,0 @@
-version: '2'
-services:
-  kibana:
-    image: docker.elastic.co/kibana/kibana:6.4.1 # kibana 이미지 사용
-    #volumes:
-    #  - ./kibana.yml:/usr/share/kibana/config/kibana.yml # 설정파일 매핑


### PR DESCRIPTION
- docker 컨테이너 환경 구성
- elasticsearch, elasticsearch2, kibana
- network : esnet
- volumes : esdata1, esdata2
- 각각 호스트 설정 및 완료
- 실제 구동시 정상적으로 3개의 서비스가 돌아가며, localhost:5601, localhost:9200으로 각각 키바나와 elasticsearch에 접근 가능